### PR TITLE
Speed and Size

### DIFF
--- a/Ecosystem/Assets/Scripts/GoToMovement.cs
+++ b/Ecosystem/Assets/Scripts/GoToMovement.cs
@@ -10,6 +10,8 @@ public sealed class GoToMovement : MonoBehaviour
   [SerializeField] private int movementSpeed;
   private Vector3 _target;
 
+  public float SpeedFactor { get; set; } = 1;
+
   /// <summary>
   ///   The target to go to.
   /// </summary>
@@ -42,7 +44,7 @@ public sealed class GoToMovement : MonoBehaviour
 
     // Move
     var direction = (Target - transform.position).normalized;
-    controller.Move(direction * (movementSpeed * Time.deltaTime));
+    controller.Move(direction * (movementSpeed * SpeedFactor * Time.deltaTime));
     transform.rotation = Quaternion.LookRotation(direction, Vector3.up);
   }
 

--- a/Ecosystem/Assets/Scripts/ICanDrink.cs
+++ b/Ecosystem/Assets/Scripts/ICanDrink.cs
@@ -7,7 +7,7 @@ public interface ICanDrink
   ///   Gets the amount of hydration the entity has.
   /// </summary>
   /// <returns>The amount of hydration the entity has.</returns>
-  int GetHydration();
+  float GetHydration();
 
   /// <summary>
   ///   Adds the amount of hydration to the entity.

--- a/Ecosystem/Assets/Scripts/ICanEat.cs
+++ b/Ecosystem/Assets/Scripts/ICanEat.cs
@@ -7,7 +7,7 @@ public interface ICanEat
   ///   Gets the amount of saturation the entity has.
   /// </summary>
   /// <returns>The amount of saturation the entity has.</returns>
-  int GetSaturation();
+  float GetSaturation();
 
   /// <summary>
   ///   Adds the amount of saturation to the entity.

--- a/Ecosystem/Assets/Scripts/NourishmentDelegate.cs
+++ b/Ecosystem/Assets/Scripts/NourishmentDelegate.cs
@@ -1,6 +1,3 @@
-using System;
-using System.Drawing;
-using UnityEditor.Experimental;
 using UnityEngine;
 
 /// <summary>
@@ -13,34 +10,20 @@ public sealed class NourishmentDelegate : ITickable
   /// <summary>
   ///   The value for which the animal is considered hungry.
   /// </summary>
-  private const int HungrySaturationLevel = 50;
+  private const float HungrySaturationLevel = 50;
 
   /// <summary>
   ///   The value for which the animal is considered thirsty.
   /// </summary>
-  private const int ThirstyHydrationLevel = 50;
+  private const float ThirstyHydrationLevel = 50;
 
-  private int _saturationDecreasePerUnit = 1;
-  private int _hydrationDecreasePerUnit = 1;
+  public float HydrationDecreasePerUnit { get; set; } = 1;
 
-  public void setMoving(bool isMoving, double size)
-  {
-    if (isMoving)
-    {
-      var newDecrease = Convert.ToInt32(Math.Pow(size, 3.0));
-      _saturationDecreasePerUnit = newDecrease;
-      _hydrationDecreasePerUnit  = newDecrease;
-    }
-    else
-    {
-      var newDecrease = Convert.ToInt32(Math.Pow(size, (0.75)));
-      _saturationDecreasePerUnit = newDecrease;
-      _hydrationDecreasePerUnit  = newDecrease;
-    }
-  }
 
-  private int _hydration;
-  private int _saturation;
+  public float SaturationDecreasePerUnit { get; set; } = 1;
+
+  private float _hydration;
+  private float _saturation;
 
   public NourishmentChanged NourishmentChangedListeners;
 
@@ -52,7 +35,13 @@ public sealed class NourishmentDelegate : ITickable
     MaxSaturation = 100;
   }
 
-  public int Saturation
+  public void SetMaxNourishment(float maxValue)
+  {
+    MaxHydration = maxValue;
+    MaxSaturation = maxValue;
+  }
+
+  public float Saturation
   {
     get => _saturation;
     set
@@ -62,7 +51,7 @@ public sealed class NourishmentDelegate : ITickable
     }
   }
 
-  public int Hydration
+  public float Hydration
   {
     get => _hydration;
     set
@@ -74,13 +63,13 @@ public sealed class NourishmentDelegate : ITickable
 
   public bool IsHungry => Saturation <= HungrySaturationLevel;
   public bool IsThirsty => Hydration <= ThirstyHydrationLevel;
-  private int MaxHydration { get; }
-  private int MaxSaturation { get; }
+  private float MaxHydration { get; set; }
+  private float MaxSaturation { get; set; }
 
   public void Tick()
   {
-    Saturation -= _saturationDecreasePerUnit;
-    Hydration -= _hydrationDecreasePerUnit;
+    Saturation -= SaturationDecreasePerUnit;
+    Hydration -= HydrationDecreasePerUnit;
 
     Invoker();
   }

--- a/Ecosystem/Assets/Scripts/NourishmentSnapshot.cs
+++ b/Ecosystem/Assets/Scripts/NourishmentSnapshot.cs
@@ -1,11 +1,11 @@
 ﻿public struct NourishmentSnapshot
 {
-  public int Saturation { get; }
-  public int Hydration { get; }
-  public int MaxSaturation { get; }
-  public int MaxHydration { get; }
+  public float Saturation { get; }
+  public float Hydration { get; }
+  public float MaxSaturation { get; }
+  public float MaxHydration { get; }
 
-  public NourishmentSnapshot(int saturation, int hydration, int maxSaturation, int maxHydration)
+  public NourishmentSnapshot(float saturation, float hydration, float maxSaturation, float maxHydration)
   {
     Saturation = saturation;
     Hydration = hydration;


### PR DESCRIPTION
Animal now have a speed and size modifier that is randomly set from 0.8 to 1.2. this means the scaling in each direction as well as the speed multiplier

The logic is placed to that the Animal class sets up the nourishment delegate at startup with the right values, the logic is in the animal class
![image](https://user-images.githubusercontent.com/42833189/108236160-e0513580-7146-11eb-9359-a194e6e61dbe.png)



Three different sized blobs next to each other:
![image](https://user-images.githubusercontent.com/42833189/108236201-e9420700-7146-11eb-846d-3900f3bef94d.png)


closes #71